### PR TITLE
#247

### DIFF
--- a/grails-app/assets/javascripts/species.show.js
+++ b/grails-app/assets/javascripts/species.show.js
@@ -537,7 +537,7 @@ function showWikipediaData(data, testPage, targetName) {
             }
 
             // fix relative links
-            $description.find(".content").html(item.innerHTML.replaceAll('href="./', "href=\"" + "https://wikipedia.org/wiki/"))
+            $description.find(".content").html(item.innerHTML.replaceAll('href="./', "href=\"" + SHOW_CONF.wikipediaWebportalUrl) + "\"")
 
             // show this description
             $description.css({'display': 'block'});

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -222,6 +222,7 @@ show:
 wikipedia:
     # https://en.wikipedia.org/api/rest_v1/#/Page%20content/get_page_html__title_
     url: https://en.wikipedia.org/api/rest_v1/page/html/
+    webportalUrl: https://en.wikipedia.org/wiki/
     lang: en
 imageServiceBaseUrl: https://images.ala.org.au/
 survey:

--- a/grails-app/views/species/show.gsp
+++ b/grails-app/views/species/show.gsp
@@ -465,7 +465,8 @@
         ausTraitsHomeUrl: "${grailsApplication.config.ausTraits.homeURL}",
         ausTraitsSourceUrl:"${grailsApplication.config.ausTraits.sourceURL}",
         showHiddenImages: false,
-        imageFilter: "${raw(grailsApplication.config.imageFilter)}"
+        imageFilter: "${raw(grailsApplication.config.imageFilter)}",
+        wikipediaWebportalUrl: "${grailsApplication.config.wikipedia.webportalUrl}"
     };
 
     $(function(){


### PR DESCRIPTION
- added config value for Wikipedia webportal URL. It should be set to the same target language as wikipedia.url. The webportalUrl is then used to resolve relative wikilinks within the wikipage.