### PR TITLE
- in species search page: make sort fields configurable

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -321,3 +321,5 @@ environments:
             preferredSpeciesListDruid: dr4778
             preferredListName: ALA Preferred Species Images
             apiKey:
+sortFields: score,scientificName,commonNameSingle,rank
+defaultSortField: score

--- a/grails-app/controllers/au/org/ala/bie/SpeciesController.groovy
+++ b/grails-app/controllers/au/org/ala/bie/SpeciesController.groovy
@@ -86,7 +86,8 @@ class SpeciesController implements GrailsConfigurationAware {
         def filterQuery = params.list('fq') // will be a list even with only one value
         def startIndex = params.offset?:0
         def rows = params.rows?:10
-        def sortField = params.sortField?:""
+        def defaultSortField = grailsApplication.config.defaultSortField
+        def sortField = params.sortField?:(defaultSortField?:"")
         def sortDirection = params.dir?:"desc"
 
         if (params.dir && !params.sortField) {

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -450,6 +450,12 @@ search.all.records=all records
 search.remove.filter=remove filter
 search.download.taxa.for.your.search=Download a list of taxa for your search
 
+search.sort.rank=taxon rank
+search.sort.commonNameSingle=common name
+search.sort.scientificName=scientific name
+search.sort.score=best match
+search.sort.occurrenceCount=occurrence count
+
 # Page overview
 overview.status.conservation=Conservation Status
 overview.online.resources=Online Resources

--- a/grails-app/views/species/search.gsp
+++ b/grails-app/views/species/search.gsp
@@ -206,18 +206,11 @@
                         <div class="form-group">
                             <label for="sort-by"><g:message code="search.sort.by"/></label>
                             <select class="form-control input-sm" id="sort-by" name="sort-by">
-                                <option value="score" ${(params.sortField == 'score') ? "selected=\"selected\"" : ""}>
-                                    <g:message code="search.sort.match"/>
-                                </option>
-                                <option value="scientificName" ${(params.sortField == 'scientificName') ? "selected=\"selected\"" : ""}>
-                                    <g:message code="search.sort.scientific"/>
-                                </option>
-                                <option value="commonNameSingle" ${(params.sortField == 'commonNameSingle') ? "selected=\"selected\"" : ""}>
-                                    <g:message code="search.sort.common"/>
-                                </option>
-                                <option value="rank" ${(params.sortField == 'rank') ? "selected=\"selected\"" : ""}>
-                                    <g:message code="search.sort.taxon"/>
-                                </option>
+                                <g:each in="${grailsApplication.config.sortFields.split(',')}" var="sortField">
+                                    <option value="${sortField}" ${(params.sortField == sortField) ? "selected=\"selected\"" : ""}>
+                                        <g:message code="search.sort.${sortField}"/>
+                                    </option>
+                                </g:each>
                             </select>
                         </div>
                         <div class="form-group">


### PR DESCRIPTION
- allow to configure default sort field so that the initial search results will be sorted by the preferred field (direction is desc; this can be made configurable as well)