### PR TITLE
inbo/vlaams-biodiversiteitsportaal#1174

### DIFF
--- a/grails-app/assets/javascripts/species.show.js
+++ b/grails-app/assets/javascripts/species.show.js
@@ -704,9 +704,10 @@ function renderPluginTabContent(data, tabMetadata, commonName, nodeType) {
     // Parse the HTML safely
     var $parsed = $("<div>").append($.parseHTML(data)); // Wrap in div so we can search
     var $content = $parsed.find("#quarto-document-content").clone();
+    $content.removeAttr("id");
     $content.appendTo("#" + tabMetadata.tab);
     initializeEcopediaWidgets(
-        $("#" + tabMetadata.tab, commonName, nodeType)
+        $("#" + tabMetadata.tab), commonName, nodeType
     );
   } else {
     var $noContentFoundMessage =


### PR DESCRIPTION
- fix a bug in JS
- remove div ID's to avoid having div's with same ID in the same HTML document in case we've got multiple plugin tabs on the species page